### PR TITLE
Enable organen creation for agbs and apbs

### DIFF
--- a/lib/processing-administrative-unit.js
+++ b/lib/processing-administrative-unit.js
@@ -23,10 +23,6 @@ export async function createAdministrativeUnitdRelationships(administrativeUnitd
   const administrativeUnit = await getAdministrativeUnitDetails(administrativeUnitdUuid);
 
   if (administrativeUnit) {
-    if (isAgb(administrativeUnit.classification) || isApb(administrativeUnit.classification)) {
-      console.warn("AGB & APB are disabled for now.");
-      return;
-    }
     const governingBodies = await createGoverningBodies(administrativeUnit);
     const governingBodiesInfo = await createGoverningBodiesInTime(administrativeUnit, governingBodies);
 
@@ -143,14 +139,6 @@ function isWorshipAdministrativeUnit(classification) {
 
 function isWorshipService(classification) {
   return classification == ADMIN_UNIT_CLASSIFICATIONS.EB;
-}
-
-function isAgb(classification) {
-  return classification == ADMIN_UNIT_CLASSIFICATIONS.AGB;
-}
-
-function isApb(classification) {
-  return classification == ADMIN_UNIT_CLASSIFICATIONS.APB;
 }
 
 function getGoverningBodyClassifications(administrativeUnit) {


### PR DESCRIPTION
OP-2527

This PR reverts https://github.com/lblod/construct-administrative-unit-relationships-service/pull/5 (minus the code formatting :grin: ). After more discussions, we decided that we are going to create the full model in OP when creating a new AGB / APB, including organen and bestuursfuncties. We are just not going to show them in OP, but we need them to be able later on to create positions on those newly created AGBs and APBs.