### PR TITLE
Fix/ocmw verenigingen

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -146,22 +146,32 @@ const politiezone = [
 // ];
 
 const welzijnsvereniging = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
 const autonomeVerzorgingsinstelling = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
 const ziekenhuisvereniging = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
 const vereniging_of_vennootschap_voor_sociale_dienstverlening = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
 const woonzorgvereniging_of_woonzorgvennootschap = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,8 +14,14 @@ export const ADMIN_UNIT_CLASSIFICATIONS = {
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562",
   POLITIEZONE:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc",
-  OCMW_VERENIGING:
-    "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
+  // Note: the OCMW verenigingen classification is not used in OP, only it's sub
+  // classifications
+  // OCMW_VERENIGING:
+  //   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
+  WELZIJNSVERENIGING:
+    "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
+  AUTONOME_VERZORGINGSINSTELLING:
+    "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267",
   DIENSTVERLENENDE_VERENIGING:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71",
   OPDRACHTHOUDENDE_VERENIGING:
@@ -121,14 +127,24 @@ const politiezone = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d", // Politieraad
 ];
 
-const ocmwVereniging = [
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
+// Note: the OCMW verenigingen classification is not used in OP, only it's sub
+// classifications
+// const ocmwVereniging = [
+//   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+//   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
+//   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+// ];
+
+const welzijnsvereniging = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+];
+
+const autonomeVerzorgingsinstelling = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
 const vgc = [
-  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/7148e12a-ae03-4a7b-bb16-7b6269b84175", // College"
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/7148e12a-ae03-4a7b-bb16-7b6269b84175", // College
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ff20fa3e-806b-4160-b74b-7483fe3a6ecd", // Collegelid
 ];
 
@@ -225,8 +241,14 @@ export const GOVERNING_BODY_CLASSIFICATIONS = {
     hulpverleningszone,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc":
     politiezone,
-  "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089":
-    ocmwVereniging,
+  // Note: the OCMW verenigingen classification is not used in OP, only it's sub
+  // classifications
+  // "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089":
+  //   ocmwVereniging,
+  "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9":
+    welzijnsvereniging,
+  "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267":
+    autonomeVerzorgingsinstelling,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c":
     vgc,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86":

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,8 +20,18 @@ export const ADMIN_UNIT_CLASSIFICATIONS = {
   //   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
   WELZIJNSVERENIGING:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
+  // Note: the following 4 UUIDs are chosen by OP, they might need to be changed
+  // if upstream ends up using different ones
   AUTONOME_VERZORGINGSINSTELLING:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267",
+  // Note: the following 3 classifications are legally not administrative units
+  // but registered organisations
+  ZIEKENHUISVERENIGING:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/82250452-83a0-48f4-89cc-b430320493ce",
+  VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/35833ba2-7371-400b-8df2-2912f66fb153",
+  WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/82fd21dc-e8bb-4d13-a010-f4a12358ef10",
   DIENSTVERLENENDE_VERENIGING:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71",
   OPDRACHTHOUDENDE_VERENIGING:
@@ -143,6 +153,18 @@ const autonomeVerzorgingsinstelling = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
+const ziekenhuisvereniging = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+];
+
+const vereniging_of_vennootschap_voor_sociale_dienstverlening = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+];
+
+const woonzorgvereniging_of_woonzorgvennootschap = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+];
+
 const vgc = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/7148e12a-ae03-4a7b-bb16-7b6269b84175", // College
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ff20fa3e-806b-4160-b74b-7483fe3a6ecd", // Collegelid
@@ -249,6 +271,12 @@ export const GOVERNING_BODY_CLASSIFICATIONS = {
     welzijnsvereniging,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267":
     autonomeVerzorgingsinstelling,
+  "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/82250452-83a0-48f4-89cc-b430320493ce":
+    ziekenhuisvereniging,
+  "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/35833ba2-7371-400b-8df2-2912f66fb153":
+    vereniging_of_vennootschap_voor_sociale_dienstverlening,
+  "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/82fd21dc-e8bb-4d13-a010-f4a12358ef10":
+    woonzorgvereniging_of_woonzorgvennootschap,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c":
     vgc,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86":


### PR DESCRIPTION
Added the classifications for the sub types of the OCMW verenigingen group. In OP  we intend to use these more specific classifications for (the to be onboarded) OCMW verenigingen.

Some notes:
- 4 of the new classification codes  (Autonome verzorgingsinstelling, Ziekenhuisvereniging, Vereniging of vennootschap voor sociale dienstverlening, and Woonzorgvereniging of woonzorgvennootschap) are not (yet) defined by data.vlaanderen but are proposed in the context of OP. These codes may be subject to change if and when upstream introduces them.
- 3 of the new classifications (Ziekenhuisvereniging, Vereniging of vennootschap voor sociale dienstverlening, and Woonzorgvereniging of woonzorgvennootschap) are not administrative units in the legal sense. But within the scope of this service they can be treated in the same way.