### PR TITLE
feat: Added classifications for other associations and corporations

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,6 +48,10 @@ export const ORGANZATION_CLASSIFICATIONS = {
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/2ad46df5-5c79-4d67-84d5-604c1377231e",
   PEVA_PROVINCE:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/088784b6-e188-48bf-b94f-94665f9e1f53",
+  ASSOCIATION_OTHER:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/3e5c8e30-95a7-47b0-b0a4-210d5bd440a7",
+  CORPORATION_OTHER:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/b9ed22af-3661-4c3e-b07f-b641d80ebf61",
 };
 
 const gemeente = [
@@ -177,6 +181,18 @@ const peva_province = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
 ];
 
+const associationOther = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+];
+
+const corporationOther = [
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943", // Raad van bestuur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528", // Algemene vergadering
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4", // Leidend Ambtenaar
+];
+
 const vgc = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/7148e12a-ae03-4a7b-bb16-7b6269b84175", // College
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ff20fa3e-806b-4160-b74b-7483fe3a6ecd", // Collegelid
@@ -295,6 +311,10 @@ export const GOVERNING_BODY_CLASSIFICATIONS = {
     worshipService,
   "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054":
     centralWorshipService,
+  "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/3e5c8e30-95a7-47b0-b0a4-210d5bd440a7":
+    associationOther,
+  "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/b9ed22af-3661-4c3e-b07f-b641d80ebf61":
+    corporationOther,
 };
 
 export const MANDATE_CLASSIFICATIONS = {


### PR DESCRIPTION
Related to OP-3023

Added the classification codes for general associations and corporations, and link these types of organisations with the *default* governing bodies. This allows to properly create these new types of organisations.

Related PRs:
- frontend: https://github.com/lblod/frontend-organization-portal/pull/628
- backend: https://github.com/lblod/app-organization-portal/pull/434