### PR TITLE
fix: add missing governing bodies for OCMW

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -69,6 +69,10 @@ const ocmw = [
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007", // Raad voor Maatschappelijk Welzijn
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008", // Vast Bureau
   "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009", // Bijzonder Comité voor de Sociale Dienst
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa", // Algemeen directeur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc", // Adjunct-algemeen directeur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35", // Financieel directeur
+  "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0", // Adjunct-financieel directeur
 ];
 
 const provincie = [


### PR DESCRIPTION
In (production) data all OCMWs also have governing bodies of classifications:
- Algemeen directeur
- Adjunct-algemeen directeur
- Financieel directeur
- Adjunct-financieel directeur

As well as the functions (nl. bestuursfuncties) that correspond to these governing bodies. This configuration change adds the governing bodies that were missing for OCMWs. The creation of the functions follows automatically from the already existing configuration.

Note: Currently OP does not provide functionality for users to create OCMWs, municipalities, and provinces. So an alternative would be to remove the unused configuration logic. 