### PR TITLE
Automate start and end dates calculation for worship services

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,3 @@ Creates the following data and links it to the organization:
 | ------------------------------------- | --------------------------------------------------------------------- | --------------------- |
 | START_DATE_NON_WORSHIP_GOVERNING_BODY | Start date of governing bodies for non worship services               | "2019-01-01T00:00:00" |
 | END_DATE_NON_WORSHIP_GOVERNING_BODY   | End date of governing bodies for non worship services (not mandatory) |                       |
-| START_DATE_WORSHIP_GOVERNING_BODY     | Start date of governing bodies for worship services                   | "2020-04-01T00:00:00" |
-| END_DATE_WORSHIP_GOVERNING_BODY       | End date of governing bodies for worship services                     | "2023-03-31T00:00:00" |

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,11 +1,13 @@
+import {
+  getDatesWorshipGoverningBody
+} from "./utils";
+
 export const START_DATE_NON_WORSHIP_GOVERNING_BODY =
   process.env.START_DATE_NON_WORSHIP_GOVERNING_BODY || "2019-01-01T00:00:00";
 export const END_DATE_NON_WORSHIP_GOVERNING_BODY =
   process.env.END_DATE_NON_WORSHIP_GOVERNING_BODY;
-export const START_DATE_WORSHIP_GOVERNING_BODY =
-  process.env.START_DATE_WORSHIP_GOVERNING_BODY || "2020-04-01T00:00:00";
-export const END_DATE_WORSHIP_GOVERNING_BODY =
-  process.env.END_DATE_WORSHIP_GOVERNING_BODY || "2023-03-31T00:00:00";
+export const START_DATE_WORSHIP_GOVERNING_BODY = getDatesWorshipGoverningBody().startDate;
+export const END_DATE_WORSHIP_GOVERNING_BODY = getDatesWorshipGoverningBody().endDate;
 
 export const ORGANZATION_CLASSIFICATIONS = {
   AGB: "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,33 @@
+/* 
+  General rule: governing body runs from April 1 (year) to March 31 (year+3).
+  Current governing body runs from April 1, 2023 to March 31, 2026
+  Next governing body runs from April 1, 2026 (2023+3) to March 31, 2029 (2026+3), etc
+*/
+export function getDatesWorshipGoverningBody() {
+  const year = new Date().getFullYear();
+  const month = new Date().getMonth();
+  
+  const yearOffset = year % 3 - 1;
+  
+  // trick to ensure we have a positive modulo value
+  const positiveYearOffset = (yearOffset + 3) % 3;
+  
+  let startYear;
+  let endYear;
+  
+  if (positiveYearOffset == 0 && month < 3) {
+    startYear = year - 3;
+    endYear = year;
+  } else {
+    startYear = year - positiveYearOffset;
+    endYear = year + (3 - positiveYearOffset);
+  }
+
+  const startDate = `${startYear}-04-01T00:00:00`;
+  const endDate = `${endYear}-03-31T00:00:00`;
+
+  return {
+    startDate,
+    endDate
+  }
+}


### PR DESCRIPTION
The start and end dates of worship services governing bodies are quite predictable as described in the comments of OP-3489:
```
The dates are quite predictable and go as follows:
- Bestuursorgaan current 1 April 2023 until 31 March 2026.
- And for the future it is 1 April 2023+3 until 31 March 2026+3.
```

This small PR automatically calculates the start and end date of governing bodies based on the current date, so that we don't have to manually change the env variable every 3 years.