### PR TITLE
OP-3844: map Regionaal zorgplatform and Andere classifications

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,6 +48,8 @@ export const ORGANIZATION_CLASSIFICATIONS = {
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/2ad46df5-5c79-4d67-84d5-604c1377231e",
   PEVA_PROVINCE:
     "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/088784b6-e188-48bf-b94f-94665f9e1f53",
+  // Deprecated by OP-3844 (codes deleted, orgs migrated to ANDERE); kept so orgs that
+  // predate the migration run don't 500 — drop once the migration has run everywhere.
   ASSOCIATION_OTHER:
     "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/3e5c8e30-95a7-47b0-b0a4-210d5bd440a7",
   CORPORATION_OTHER:
@@ -64,6 +66,11 @@ export const ORGANIZATION_CLASSIFICATIONS = {
     "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/b22948f9-e695-4f24-a530-b6bf3af3b37f",
   WOONMAATSCHAPPIJ:
     "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/f4e5bb57-1007-4397-828b-b34bbf1e760d",
+  REGIONAAL_ZORGPLATFORM:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/e3afe092-6ca6-4685-94c6-1ee20811efc4",
+  // Residual category replacing ASSOCIATION_OTHER / CORPORATION_OTHER (OP-3844):
+  ANDERE:
+    "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/7a199d27-31c3-44bb-a58f-b3a64673a8b6",
 };
 
 ////////////////////////////////////////////////////
@@ -396,6 +403,22 @@ const woonmaatschappij = [
   LEIDEND_AMBTENAAR
 ];
 
+// Regionaal zorgplatform: same legal figure as the zorgraad (privaatrechtelijke vereniging met
+// rechtspersoonlijkheid, decreet eerstelijnszorg 26/04/2019 art. 15) -> standard VZW organs.
+const regionaalZorgplatform = [
+  RAAD_VAN_BESTUUR,
+  ALGEMENE_VERGADERING,
+  LEIDEND_AMBTENAAR
+];
+
+// Residual category (OP-3844): standard organs, preserving the behaviour of the
+// associationOther / corporationOther codes it replaces.
+const andere = [
+  RAAD_VAN_BESTUUR,
+  ALGEMENE_VERGADERING,
+  LEIDEND_AMBTENAAR
+];
+
 // Vervoerregioraad is an overlegorgaan (geen rechtspersoonlijkheid), modeled as the raad itself:
 // a single bestuursorgaan with leden + a voorzitter (codes minted in the onboarding migration).
 const vervoerregioraad = [
@@ -534,6 +557,10 @@ export const GOVERNING_BODY_CLASSIFICATIONS = {
     bosgroep,
   [ORGANIZATION_CLASSIFICATIONS.WOONMAATSCHAPPIJ]:
     woonmaatschappij,
+  [ORGANIZATION_CLASSIFICATIONS.REGIONAAL_ZORGPLATFORM]:
+    regionaalZorgplatform,
+  [ORGANIZATION_CLASSIFICATIONS.ANDERE]:
+    andere,
   [ORGANIZATION_CLASSIFICATIONS.VERVOERREGIORAAD]:
     vervoerregioraad,
   [ORGANIZATION_CLASSIFICATIONS.INTERLOKALE_VERENIGING]:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "construct-organization-relationships-service",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Microservice to construct the governing bodies, mandates and ministers of an organization",
   "repository": {
     "type": "git",


### PR DESCRIPTION
cf https://github.com/lblod/app-organization-portal/pull/611

Standard VZW organs (RvB, AV, leidend ambtenaar) for both: the platform mirrors the zorgraad; "Andere" preserves the behaviour of the ASSOCIATION_OTHER / CORPORATION_OTHER codes it replaces. Includes the 1.1.4 version bump.
